### PR TITLE
Normalize header levels in new note

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,21 @@ The following placeholders are supported and will be replaced with dynamic value
 - `{{new_note_title}}` the title of the new note.
 - `{{new_note_content}}` the refactored content for the new note.
 
+### Normalize Heading Levels
+
+This setting normalizes the levels of the headings in an extracted note.
+
+For example,
+```
+## Heading 2
+### Heading 3
+```
+becomes
+```
+# Heading 2
+## Heading 3
+```
+
 ## Compatibility
 
 Custom plugins are only available for Obsidian v0.9.7+.

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -120,6 +120,37 @@ export default class NRDoc {
         //Adds first line back into content if it is not to be included as a header or if the command is content only
         contentArr.unshift(firstLine);
       }
+      if(this.settings.normalizeHeaderLevels){
+        contentArr = this.normalizeHeadingLevels(contentArr);
+      }
       return contentArr.join('\n').trim();
+    }
+
+    normalizeHeadingLevels(contentArr:string[]): string[] {
+      const minHeadingLevel = Math.min(...contentArr.map(line => this.headingLevel(line)).filter(level => level > 0));
+      if(minHeadingLevel > 1) {
+        contentArr.forEach((line, i) => {
+          const level = this.headingLevel(line);
+          if (level > 0) {
+            contentArr[i] = line.substr(minHeadingLevel - 1);
+          }
+        });
+      }
+      return contentArr;
+    }
+
+    headingLevel(line: string): number {
+      let headingLevel = 0;
+      for (let i = 0; i < line.length; i++) {
+        if (line[i] === '#') {
+          headingLevel++;
+        } else if(line[i] === ' '){
+          break;
+        } else {
+          headingLevel = 0;
+          break;
+        }
+      }
+      return headingLevel;
     }
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -152,6 +152,15 @@ export class NoteRefactorSettingsTab extends PluginSettingTab {
               this.plugin.saveData(this.plugin.settings);
             }));
     }
+
+    new Setting(containerEl)
+      .setName('Normalize heading levels')
+      .setDesc('When content has been extracted/split into a new note, normalize the levels of the headings')
+      .addToggle(toggle => toggle.setValue(this.plugin.settings.normalizeHeaderLevels)
+        .onChange((value) => {
+          this.plugin.settings.normalizeHeaderLevels = value;
+          this.plugin.saveData(this.plugin.settings);
+        }));
   }
 
   private tempalteDescriptionContent(introText: string): DocumentFragment {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export class NoteRefactorSettings {
     transcludeByDefault: boolean = false;
     noteLinkTemplate: string = '';
     refactoredNoteTemplate: string = '';
+    normalizeHeaderLevels: boolean = false;
   }
   
 export enum Location {

--- a/tests/doc.test.ts
+++ b/tests/doc.test.ts
@@ -33,6 +33,38 @@ describe("Note content - Content Only", () => {
 
 });
 
+describe("Note content - Content Only - Normalize header levels", () => {
+
+    before(async () => {
+        fileContents = await loadTestFile();
+        content = toArray(fileContents, 42, 51);
+        const settings = new NoteRefactorSettings();
+        settings.normalizeHeaderLevels = true;
+        doc = new NRDoc(settings, undefined, undefined);
+    });
+
+    it("First line content", () => {
+        const noteContent = doc.noteContent(content[0], content.slice(1), true);
+        assert.equal(firstLine(noteContent), "# I have questions.");
+    });
+
+    it("Header 3 content", () => {
+        const noteContent = doc.noteContent(content[0], content.slice(1), true);
+        assert.equal(toArray(noteContent)[4], "## Header 3");
+    });
+
+    it("Last line content", () => {
+        const noteContent = doc.noteContent(content[0], content.slice(1), true);
+        assert.equal(lastLine(noteContent), "This is for testing normalizing header levels.");
+    });
+
+    it("Character count", () => {
+        const noteContent = doc.noteContent(content[0], content.slice(1), true);
+        assert.equal(noteContent.length, 232);
+    });
+
+});
+
 describe("Note content - First Line as File Name, exclude first line", () => {
 
     before(async () => {

--- a/tests/files/test-note.md
+++ b/tests/files/test-note.md
@@ -43,3 +43,7 @@ By the way, you can feel free to edit these help docs, but when you click Settin
 ## I have questions.
 
 Then you should join our [community!](https://obsidian.md/community). We have active Discord and Forums, and the community is generally quite helpful.
+
+### Header 3
+
+This is for testing normalizing header levels.


### PR DESCRIPTION
This setting normalizes the levels of the headings in an extracted note. #39 
For example,
```
## Heading 2
### Heading 3
```
becomes
```
# Heading 2
## Heading 3
```