### PR TITLE
Split Note by Heading: Add support for h4, h5, and h6

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ This command splits the current note into a new note from the current line using
 
 This command splits the current note into a new note, or append to an existing one, from the current line. The user is prompted to enter a file name for the new note.
 
-#### Split note by headings - H1, H2, H3
+#### Split note by headings - H1, H2, H3, H4, H5, H6
 
-This command splits the current note into a new note for every heading at the level selected (H1, H2 or H3) using the heading as the file name for each new note.
+This command splits the current note into a new note for every heading at the level selected (H1, H2, H3, H4, H5, or H6) using the heading as the file name for each new note.
 
 ![split by headings demo](https://raw.githubusercontent.com/lynchjames/note-refactor-obsidian/master/images/Note-Refactor-Demo-Split-by-Headings.gif)
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "note-refactor-obsidian",
   "name": "Note Refactor",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Extract note content into new notes and split notes",
   "isDesktopOnly": false,
   "js": "main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,6 +94,24 @@ export default class NoteRefactor extends Plugin {
       name: 'Split note by headings - H3',
       callback: () => this.editModeGuard(() => this.splitOnHeading(3)),
     });
+    
+    this.addCommand({
+      id: 'app:split-note-by-heading-h4',
+      name: 'Split note by headings - H4',
+      callback: () => this.editModeGuard(() => this.splitOnHeading(4)),
+    });
+
+    this.addCommand({
+      id: 'app:split-note-by-heading-h5',
+      name: 'Split note by headings - H5',
+      callback: () => this.editModeGuard(() => this.splitOnHeading(5)),
+    });
+
+    this.addCommand({
+      id: 'app:split-note-by-heading-h6',
+      name: 'Split note by headings - H6',
+      callback: () => this.editModeGuard(() => this.splitOnHeading(6)),
+    });
 
     this.addSettingTab(new NoteRefactorSettingsTab(this.app, this));
   }


### PR DESCRIPTION
This extends the current functionality and adds support for splitting by more headings.

![image](https://github.com/lynchjames/note-refactor-obsidian/assets/23527429/4c337dbb-c895-4ffd-86a5-0cfadd9ae82a)
