### PR TITLE
Add new_title Placeholder for Prefix-Stripped Titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The following placeholders are supported and will be replaced with dynamic value
 - `{{title}}` the title of the original note.
 - `{{new_note_title}}` the title of the new note.
 - `{{new_note_content}}` the refactored content for the new note.
+- `{{new_title}}` the title of the new note.
 
 ### Refactored Note Template
 
@@ -148,6 +149,7 @@ The following placeholders are supported and will be replaced with dynamic value
 - `{{title}}` the title of the original note.
 - `{{new_note_title}}` the title of the new note.
 - `{{new_note_content}}` the refactored content for the new note.
+- `{{new_title}}` the title of the new note.
 
 ### Normalize Heading Levels
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The following placeholders are supported and will be replaced with dynamic value
 - `{{title}}` the title of the original note.
 - `{{new_note_title}}` the title of the new note.
 - `{{new_note_content}}` the refactored content for the new note.
-- `{{new_title}}` the title of the new note.
+- `{{new_title}}` the title of the new note without prefix.
 
 ### Refactored Note Template
 
@@ -149,7 +149,7 @@ The following placeholders are supported and will be replaced with dynamic value
 - `{{title}}` the title of the original note.
 - `{{new_note_title}}` the title of the new note.
 - `{{new_note_content}}` the refactored content for the new note.
-- `{{new_title}}` the title of the new note.
+- `{{new_title}}` the title of the new note without prefix.
 
 ### Normalize Heading Levels
 

--- a/data.json
+++ b/data.json
@@ -1,0 +1,13 @@
+{
+  "includeFirstLineAsNoteHeading": false,
+  "excludeFirstLineInNote": false,
+  "openNewNote": true,
+  "headingFormat": "#",
+  "newFileLocation": 0,
+  "customFolder": "",
+  "fileNamePrefix": "{{date:YYYYMMDDHHmmss}}_",
+  "transcludeByDefault": false,
+  "noteLinkTemplate": "",
+  "refactoredNoteTemplate": "{{new_title}}\n\n\n{{new_note_content}}",
+  "normalizeHeaderLevels": false
+}

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -5,7 +5,7 @@ import { NotePlaceholders } from './placeholder';
 import { NoteRefactorSettings } from './settings';
 export type ReplaceMode = 'split' | 'replace-selection' | 'replace-headings';
 
-export default class  {
+export default class NRDoc {
     private settings: NoteRefactorSettings;
     private templatePlaceholders: NotePlaceholders;
     private momentRegex: MomentDateRegex;

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -26,13 +26,13 @@ export default class NRDoc {
         doc.replaceRange(text, currentLine, endPosition);
     }
 
-    async replaceContent(fileName: string, filePath: string, doc:Editor, currentNote: TFile, content: string, originalContent: string, mode: ReplaceMode): Promise<void> {
+    async replaceContent(fileName: string, filePath: string, doc:Editor, currentNote: TFile, content: string, originalContent: string, newTitle: string, mode: ReplaceMode): Promise<void> {
         const transclude = this.settings.transcludeByDefault ? '!' : '';
         const link = await this.markdownLink(filePath);
         const currentNoteLink = await this.markdownLink(currentNote.path);
         let contentToInsert = transclude + link;
         
-        contentToInsert = this.templatedContent(contentToInsert, this.settings.noteLinkTemplate, currentNote.basename, currentNoteLink, fileName, link, '', content);
+        contentToInsert = this.templatedContent(contentToInsert, this.settings.noteLinkTemplate, currentNote.basename, currentNoteLink, fileName, link, '', content, newTitle);
 
         if(mode === 'split'){ 
             this.removeNoteRemainder(doc, contentToInsert);
@@ -49,7 +49,7 @@ export default class NRDoc {
       return link;
     }
 
-    templatedContent(input: string, template: string, currentNoteTitle: string, currentNoteLink: string, newNoteTitle: string, newNoteLink: string, newNotePath: string, newNoteContent: string): string {
+    templatedContent(input: string, template: string, currentNoteTitle: string, currentNoteLink: string, newNoteTitle: string, newNoteLink: string, newNotePath: string, newNoteContent: string, newTitle: string): string {
       if(template === undefined || template === ''){
         return input;
       }
@@ -60,6 +60,7 @@ export default class NRDoc {
       output = this.templatePlaceholders.newNoteTitle.replace(output, newNoteTitle);
       output = this.templatePlaceholders.newNoteLink.replace(output, newNoteLink);
       output = this.templatePlaceholders.newNoteContent.replace(output, newNoteContent);
+      output = this.templatePlaceholders.newTitle.replace(output, newTitle);
       output = this.templatePlaceholders.newNotePath.replace(output, newNotePath);
       return output;
     }

--- a/src/doc.ts
+++ b/src/doc.ts
@@ -5,7 +5,7 @@ import { NotePlaceholders } from './placeholder';
 import { NoteRefactorSettings } from './settings';
 export type ReplaceMode = 'split' | 'replace-selection' | 'replace-headings';
 
-export default class NRDoc {
+export default class  {
     private settings: NoteRefactorSettings;
     private templatePlaceholders: NotePlaceholders;
     private momentRegex: MomentDateRegex;

--- a/src/file.ts
+++ b/src/file.ts
@@ -15,6 +15,11 @@ export default class NRFile {
 		const headerRegex = FILE_NAME_REGEX;
 		const prefix = this.fileNamePrefix();
 		const checkedPrefix = unsanitisedFilename.startsWith(prefix) ? "" : prefix;
+
+		if(this.settings.onlyUsePrefixAsFileName){
+			return checkedPrefix;
+		}
+		
 		return (
 			checkedPrefix +
 			unsanitisedFilename.replace(headerRegex, "").trim().slice(0, 255)

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,36 +1,45 @@
-import { FILE_NAME_REGEX } from './constants'
-import { NoteRefactorSettings } from './settings';
-import MomentDateRegex from './moment-date-regex'
+import { FILE_NAME_REGEX } from "./constants";
+import { NoteRefactorSettings } from "./settings";
+import MomentDateRegex from "./moment-date-regex";
 
 export default class NRFile {
-    
-    private settings: NoteRefactorSettings;
-    private momentDateRegex: MomentDateRegex;
+	private settings: NoteRefactorSettings;
+	private momentDateRegex: MomentDateRegex;
 
-    constructor(setting: NoteRefactorSettings) {
-        this.settings = setting;
-        this.momentDateRegex = new MomentDateRegex();
-    }
+	constructor(setting: NoteRefactorSettings) {
+		this.settings = setting;
+		this.momentDateRegex = new MomentDateRegex();
+	}
 
-    sanitisedFileName(unsanitisedFilename: string): string {
-      const headerRegex = FILE_NAME_REGEX;
-      const prefix = this.fileNamePrefix();
-      const checkedPrefix = unsanitisedFilename.startsWith(prefix) ? '' : prefix;
-      return checkedPrefix + unsanitisedFilename.replace(headerRegex, '').trim().slice(0, 255);
-    }
+	sanitisedFileName(unsanitisedFilename: string): string {
+		const headerRegex = FILE_NAME_REGEX;
+		const prefix = this.fileNamePrefix();
+		const checkedPrefix = unsanitisedFilename.startsWith(prefix) ? "" : prefix;
+		return (
+			checkedPrefix +
+			unsanitisedFilename.replace(headerRegex, "").trim().slice(0, 255)
+		);
+	}
 
-    fileNamePrefix(): string {
-      return this.settings.fileNamePrefix ? this.momentDateRegex.replace(this.settings.fileNamePrefix) : '';
-    }
+	fileNamePrefix(): string {
+		return this.settings.fileNamePrefix
+			? this.momentDateRegex.replace(this.settings.fileNamePrefix)
+			: "";
+	}
 
-    ensureUniqueFileNames(headingNotes: string[][]): string[] {
-      const fileNames:string[] = [];
-      const deduped = headingNotes.map((hn) => {
-        const fileName = this.sanitisedFileName(hn[0]);
-        const duplicates = fileNames.filter(fn => fn == fileName);
-        fileNames.push(fileName);
-        return duplicates.length >= 1 ? `${fileName}${duplicates.length + 1}` : fileName;
-      });
-      return deduped;
-    }
+	ensureUniqueFileNames(headingNotes: string[][]): string[] {
+		const fileNames: string[] = [];
+		const deduped = headingNotes.map((hn) => {
+			const fileName = this.sanitisedFileName(hn[0]);
+			const duplicates = fileNames.filter((fn) => fn == fileName);
+			fileNames.push(fileName);
+			return duplicates.length >= 1
+				? `${fileName}${duplicates.length + 1}`
+				: fileName;
+		});
+		return deduped;
+	}
+	getNewTitle(firstLine: string): string {
+		return firstLine.replace(/^#+ /, "").trim();
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,17 +147,18 @@ export default class NoteRefactor extends Plugin {
 
     const fileName = this.file.fileNamePrefix(); // Only prefix is used for the note file name
     const originalNote = this.NRDoc.noteContent(header, contentArr);
+    const newTitle = this.file.getNewTitle(header);
     let note = originalNote;
     const filePath = await this.obsFile.createOrAppendFile(fileName, '');
 
     if (this.settings.refactoredNoteTemplate !== undefined && this.settings.refactoredNoteTemplate !== '') {
       const link = await this.app.fileManager.generateMarkdownLink(mdView.file, '', '', '');
       const newNoteLink = await this.NRDoc.markdownLink(filePath);
-      note = this.NRDoc.templatedContent(note, this.settings.refactoredNoteTemplate, mdView.file.basename, link, fileName, newNoteLink, '', note);
+      note = this.NRDoc.templatedContent(note, this.settings.refactoredNoteTemplate, mdView.file.basename, link, fileName, newNoteLink, '', note, newTitle);
     }
 
     await this.obsFile.createOrAppendFile(fileName, note);
-    await this.NRDoc.replaceContent(fileName, filePath, doc, mdView.file, note, originalNote, mode);
+    await this.NRDoc.replaceContent(fileName, filePath, doc, mdView.file, note, originalNote, newTitle, mode);
     if(!isMultiple) {
         await this.app.workspace.openLinkText(fileName, getLinkpath(filePath), true);
     }
@@ -167,6 +168,7 @@ export default class NoteRefactor extends Plugin {
     const [originalHeader, ...contentArr] = selectedContent;
 
     const fileName = this.file.sanitisedFileName(dedupedHeader);
+    const newTitle = this.file.getNewTitle(dedupedHeader);
     const originalNote = this.NRDoc.noteContent(originalHeader, contentArr);
     let note = originalNote;
     const filePath = await this.obsFile.createOrAppendFile(fileName, '');
@@ -174,10 +176,10 @@ export default class NoteRefactor extends Plugin {
     if (this.settings.refactoredNoteTemplate !== undefined && this.settings.refactoredNoteTemplate !== '') {
       const link = await this.app.fileManager.generateMarkdownLink(mdView.file, '', '', '');
       const newNoteLink = await this.NRDoc.markdownLink(filePath);
-      note = this.NRDoc.templatedContent(note, this.settings.refactoredNoteTemplate, mdView.file.basename, link, fileName, newNoteLink, '', note);
+      note = this.NRDoc.templatedContent(note, this.settings.refactoredNoteTemplate, mdView.file.basename, link, fileName, newNoteLink, '', note, newTitle);
     }
     await this.obsFile.createOrAppendFile(fileName, note);
-    await this.NRDoc.replaceContent(fileName, filePath, doc, mdView.file, note, originalNote, mode);
+    await this.NRDoc.replaceContent(fileName, filePath, doc, mdView.file, note, originalNote, newTitle, mode);
     if(!isMultiple && this.settings.openNewNote) {
         await this.app.workspace.openLinkText(fileName, getLinkpath(filePath), true);
     }

--- a/src/modal-note-creation.ts
+++ b/src/modal-note-creation.ts
@@ -59,7 +59,7 @@ export default class ModalNoteCreation {
         if(this.settings.refactoredNoteTemplate !== undefined && this.settings.refactoredNoteTemplate !== '') {
           const currentFileLink = await this.doc.markdownLink(curerntFile.path);
           const fileLink = await this.doc.markdownLink(filePath);
-          return this.doc.templatedContent(note, this.settings.refactoredNoteTemplate, curerntFile.basename, currentFileLink, fileName, fileLink, '', fileName, note);
+          return this.doc.templatedContent(note, this.settings.refactoredNoteTemplate, curerntFile.basename, currentFileLink, fileName, fileLink, '', note, fileName);
         }
         return note;
       }

--- a/src/modal-note-creation.ts
+++ b/src/modal-note-creation.ts
@@ -59,7 +59,7 @@ export default class ModalNoteCreation {
         if(this.settings.refactoredNoteTemplate !== undefined && this.settings.refactoredNoteTemplate !== '') {
           const currentFileLink = await this.doc.markdownLink(curerntFile.path);
           const fileLink = await this.doc.markdownLink(filePath);
-          return this.doc.templatedContent(note, this.settings.refactoredNoteTemplate, curerntFile.basename, currentFileLink, fileName, fileLink, '', note);
+          return this.doc.templatedContent(note, this.settings.refactoredNoteTemplate, curerntFile.basename, currentFileLink, fileName, fileLink, '', fileName, note);
         }
         return note;
       }

--- a/src/modal-note-creation.ts
+++ b/src/modal-note-creation.ts
@@ -32,7 +32,7 @@ export default class ModalNoteCreation {
         const filePath = await this.obsFile.createOrAppendFile(fileName, '');
         const templatedContent = await this.templatedContent(this.content, currentFile, filePath, fileName);
         await this.obsFile.createOrAppendFile(fileName, templatedContent)
-        await this.doc.replaceContent(fileName, filePath, this.editor, currentFile, templatedContent, this.content, this.mode);
+        await this.doc.replaceContent(fileName, filePath, this.editor, currentFile, templatedContent, this.content, fileName, this.mode);
         if(this.settings.openNewNote){
           this.app.workspace.openLinkText(fileName, getLinkpath(filePath), true);
         }
@@ -43,7 +43,7 @@ export default class ModalNoteCreation {
         const templatedContent = await this.templatedContent(this.content, currentFile, file.path, file.basename);
         existingContent = existingContent ?? (await this.app.vault.read(file) + '\r\r');
         await this.app.vault.modify(file, existingContent + templatedContent);
-        await this.doc.replaceContent(file.basename, file.path, this.editor, currentFile, templatedContent, this.content, this.mode);
+        await this.doc.replaceContent(file.basename, file.path, this.editor, currentFile, templatedContent, this.content, file.basename, this.mode);
         if(this.settings.openNewNote){
           this.app.workspace.openLinkText(file.basename, getLinkpath(file.path), true);
         }

--- a/src/placeholder.ts
+++ b/src/placeholder.ts
@@ -1,21 +1,22 @@
 export class NotePlaceholders {
-    newNoteTitle = new Placeholder('new_note_title');
-    newNoteLink = new Placeholder('new_note_link');
-    newNotePath = new Placeholder('new_note_path');
-    newNotePathEncoded = new Placeholder('new_note_path_encoded');
-    newNoteContent = new Placeholder('new_note_content');
-    title = new Placeholder('title');
-    link = new Placeholder('link');
+	newNoteTitle = new Placeholder("new_note_title");
+	newNoteLink = new Placeholder("new_note_link");
+	newNotePath = new Placeholder("new_note_path");
+	newNotePathEncoded = new Placeholder("new_note_path_encoded");
+	newNoteContent = new Placeholder("new_note_content");
+	newTitle = new Placeholder("new_title");
+	title = new Placeholder("title");
+	link = new Placeholder("link");
 }
 
 export class Placeholder {
-    key: string;
+	key: string;
 
-    constructor(key: string) {
-        this.key = key;
-    }
+	constructor(key: string) {
+		this.key = key;
+	}
 
-    replace(input: string, value: string): string {
-        return input.replace(new RegExp(`\{\{${this.key}\}\}`, 'gmi'), () => value);
-    }
+	replace(input: string, value: string): string {
+		return input.replace(new RegExp(`\{\{${this.key}\}\}`, "gmi"), () => value);
+	}
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -169,7 +169,7 @@ export class NoteRefactorSettingsTab extends PluginSettingTab {
     descEl.appendChild(document.createElement('br'));
     descEl.appendText('Supported placeholders:');
     descEl.appendChild(document.createElement('br'));
-    descEl.appendText('{{date}} {{title}} {{link}} {{new_note_title}} {{new_note_link}} {{new_note_content}}');
+    descEl.appendText('{{date}} {{title}} {{link}} {{new_note_title}} {{new_note_link}} {{new_note_content}} {{new_title}}');
     return descEl;
   }
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -161,6 +161,15 @@ export class NoteRefactorSettingsTab extends PluginSettingTab {
           this.plugin.settings.normalizeHeaderLevels = value;
           this.plugin.saveData(this.plugin.settings);
         }));
+
+    new Setting(containerEl)
+    .setName('Use only prefixe as file name')
+    .setDesc('Only the specified prefix is used as the file name.')
+    .addToggle(toggle => toggle.setValue(this.plugin.settings.onlyUsePrefixAsFileName)
+      .onChange((value) => {
+        this.plugin.settings.onlyUsePrefixAsFileName = value;
+        this.plugin.saveData(this.plugin.settings);
+      }));
   }
 
   private tempalteDescriptionContent(introText: string): DocumentFragment {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export class NoteRefactorSettings {
     noteLinkTemplate: string = '';
     refactoredNoteTemplate: string = '';
     normalizeHeaderLevels: boolean = false;
+    onlyUsePrefixAsFileName: boolean = false;
   }
   
 export enum Location {


### PR DESCRIPTION
This pull request introduces a new placeholder called new_title, which holds the title of a new note minus any prefix. Previously, we had a placeholder named new_note_title that includes the prefix in the title. However, there has been interest in having a version of the title without the prefix, as seen in the discussions in issues #72 and #80.

The new_title placeholder can be useful for users who prefer a cleaner or more concise title for their notes, especially when the prefix is not desired. This change aims to address the needs of such users and improve the flexibility of title formatting in the plugin.

Fixes #72
Fixes #80